### PR TITLE
Return a Joke from the ApiControllers via callback

### DIFF
--- a/app/src/main/java/com/grjug/android/chucknorrisjokes/api/controller/ChuckNorrisApiController.java
+++ b/app/src/main/java/com/grjug/android/chucknorrisjokes/api/controller/ChuckNorrisApiController.java
@@ -4,6 +4,7 @@ import android.content.Context;
 
 import com.android.volley.Response;
 import com.grjug.android.chucknorrisjokes.api.dao.ChuckNorrisApiDao;
+import com.grjug.android.chucknorrisjokes.api.util.JokeCallback;
 
 import org.json.JSONObject;
 
@@ -25,12 +26,8 @@ public class ChuckNorrisApiController {
         return controller;
     }
 
-    public void getRandomJoke(Response.Listener<JSONObject> responseListener, Response.ErrorListener errorListener) {
-        apiDao.getRandomJoke(responseListener, errorListener);
-    }
-
-    public void getJokeById(int id, Response.Listener<JSONObject> responseListener, Response.ErrorListener errorListener) {
-        apiDao.getJokeById(id, responseListener, errorListener);
+    public void getJokeById(int id, JokeCallback callback) {
+        apiDao.getJokeById(id, callback);
     }
 
     public void getNumberOfJokes(Response.Listener<JSONObject> responseListener, Response.ErrorListener errorListener) {

--- a/app/src/main/java/com/grjug/android/chucknorrisjokes/api/dao/ChuckNorrisApiDao.java
+++ b/app/src/main/java/com/grjug/android/chucknorrisjokes/api/dao/ChuckNorrisApiDao.java
@@ -3,8 +3,12 @@ package com.grjug.android.chucknorrisjokes.api.dao;
 import android.content.Context;
 
 import com.android.volley.Response;
+import com.android.volley.VolleyError;
 import com.grjug.android.chucknorrisjokes.api.util.ChuckNorrisApiUtil;
+import com.grjug.android.chucknorrisjokes.api.util.JokeCallback;
+import com.grjug.android.chucknorrisjokes.model.Joke;
 
+import org.json.JSONException;
 import org.json.JSONObject;
 
 /**
@@ -17,12 +21,30 @@ public class ChuckNorrisApiDao {
         this.apiUtil = new ChuckNorrisApiUtil(context);
     }
 
-    public void getRandomJoke(Response.Listener<JSONObject> responseListener, Response.ErrorListener errorListener) {
-        apiUtil.queueGetRandomJoke(responseListener, errorListener);
-    }
+    public void getJokeById(int id, final JokeCallback callback) {
+        apiUtil.queueGetJokeById(id, new Response.Listener<JSONObject>() {
+            @Override
+            public void onResponse(JSONObject jsonObject) {
+                try {
+                    Joke joke = new Joke();
 
-    public void getJokeById(int id, Response.Listener<JSONObject> responseListener, Response.ErrorListener errorListener) {
-        apiUtil.queueGetJokeById(id, responseListener, errorListener);
+                    String jokeText = jsonObject.getJSONObject("value").getString("joke");
+                    int jokeId = jsonObject.getJSONObject("value").getInt("id");
+
+                    joke.setText(jokeText);
+                    joke.setId(jokeId);
+                    callback.success(joke);
+
+                } catch (JSONException e) {
+                    callback.failure(e.getMessage());
+                }
+            }
+        }, new Response.ErrorListener() {
+            @Override
+            public void onErrorResponse(VolleyError volleyError) {
+                callback.failure(volleyError.getMessage());
+            }
+        });
     }
 
     public void getNumberOfJokes(Response.Listener<JSONObject> responseListener, Response.ErrorListener errorListener) {
@@ -32,4 +54,5 @@ public class ChuckNorrisApiDao {
     public void getCategories(Response.Listener<JSONObject> responseListener, Response.ErrorListener errorListener) {
         apiUtil.queueGetCategories(responseListener, errorListener);
     }
+
 }

--- a/app/src/main/java/com/grjug/android/chucknorrisjokes/api/util/ChuckNorrisApiUtil.java
+++ b/app/src/main/java/com/grjug/android/chucknorrisjokes/api/util/ChuckNorrisApiUtil.java
@@ -7,6 +7,7 @@ import com.android.volley.RequestQueue;
 import com.android.volley.Response;
 import com.android.volley.toolbox.JsonObjectRequest;
 import com.android.volley.toolbox.Volley;
+import com.grjug.android.chucknorrisjokes.model.Joke;
 
 import org.json.JSONObject;
 
@@ -15,7 +16,6 @@ import org.json.JSONObject;
  */
 public class ChuckNorrisApiUtil {
     private RequestQueue requestQueue;
-    private static final String RANDOM_URL = "http://api.icndb.com/jokes/random";
     private static final String GET_JOKE_URL = "http://api.icndb.com/jokes/";
     private static final String COUNT_URL = "http://api.icndb.com/jokes/count";
     private static final String CATEGORY_URL = "http://api.icndb.com/jokes/categories";
@@ -24,15 +24,9 @@ public class ChuckNorrisApiUtil {
         requestQueue = Volley.newRequestQueue(context);
     }
 
-    public void queueGetRandomJoke(Response.Listener<JSONObject> responseListener, Response.ErrorListener errorListener) {
-        queueRequest(RANDOM_URL, responseListener, errorListener);
-    }
-
     public void queueGetJokeById(int id, Response.Listener<JSONObject> responseListener, Response.ErrorListener errorListener) {
-        if (id == 0)
-            return;
+        String url = GET_JOKE_URL + (id == Joke.RANDOM_ID ? "random" : id);
 
-        String url = GET_JOKE_URL + id;
         queueRequest(url, responseListener, errorListener);
     }
 

--- a/app/src/main/java/com/grjug/android/chucknorrisjokes/api/util/JokeCallback.java
+++ b/app/src/main/java/com/grjug/android/chucknorrisjokes/api/util/JokeCallback.java
@@ -1,0 +1,10 @@
+package com.grjug.android.chucknorrisjokes.api.util;
+import com.grjug.android.chucknorrisjokes.model.Joke;
+
+/**
+ * Created by joshuakovach on 5/20/14.
+ */
+public interface JokeCallback {
+    public void success(Joke joke);
+    public void failure(String errorMessage);
+}

--- a/app/src/main/java/com/grjug/android/chucknorrisjokes/model/Joke.java
+++ b/app/src/main/java/com/grjug/android/chucknorrisjokes/model/Joke.java
@@ -6,8 +6,10 @@ import java.util.List;
  * Created by emonk on 3/18/14.
  */
 public class Joke {
+    public static final int RANDOM_ID = 0;
+
     Integer id;
-    String jokeText;
+    String text;
     List<String> categories;
 
     public Integer getId() {
@@ -18,12 +20,12 @@ public class Joke {
         this.id = id;
     }
 
-    public String getJokeText() {
-        return jokeText;
+    public String getText() {
+        return text;
     }
 
-    public void setJokeText(String jokeText) {
-        this.jokeText = jokeText;
+    public void setText(String text) {
+        this.text = text;
     }
 
     public List<String> getCategories() { return categories; }

--- a/app/src/main/java/com/grjug/android/chucknorrisjokes/persistence/DatabaseHelper.java
+++ b/app/src/main/java/com/grjug/android/chucknorrisjokes/persistence/DatabaseHelper.java
@@ -105,7 +105,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
 
         ContentValues values = new ContentValues();
         values.put(JOKE.COLUMNS._ID, joke.getId());
-        values.put(JOKE.COLUMNS.KEY_JOKE_TEXT, joke.getJokeText());
+        values.put(JOKE.COLUMNS.KEY_JOKE_TEXT, joke.getText());
         values.put(JOKE.COLUMNS.KEY_THUMBS_UP, thumbsUp);
         values.put(JOKE.COLUMNS.KEY_CREATED_AT, new Date().toString());
 

--- a/app/src/main/java/com/grjug/android/chucknorrisjokes/ui/RandomJokeActivity.java
+++ b/app/src/main/java/com/grjug/android/chucknorrisjokes/ui/RandomJokeActivity.java
@@ -8,13 +8,10 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
 
-import com.android.volley.Response;
-import com.android.volley.VolleyError;
 import com.grjug.android.chucknorrisjokes.R;
 import com.grjug.android.chucknorrisjokes.api.controller.ChuckNorrisApiController;
-
-import org.json.JSONException;
-import org.json.JSONObject;
+import com.grjug.android.chucknorrisjokes.api.util.JokeCallback;
+import com.grjug.android.chucknorrisjokes.model.Joke;
 
 /**
  * Created by carlushenry on 3/25/14.
@@ -44,22 +41,16 @@ public class RandomJokeActivity extends ActionBarActivity {
     }
 
     private void refreshRandomJoke() {
-        controller.getRandomJoke(new Response.Listener<JSONObject>() {
-                                     @Override
-                                     public void onResponse(JSONObject jsonObject) {
-                                         try {
-                                             txtJoke.setText(jsonObject.getJSONObject("value").getString("joke"));
-                                         } catch (JSONException e) {
-                                             txtJoke.setText(e.getMessage());
-                                         }
-                                     }
-                                 }, new Response.ErrorListener() {
-                                     @Override
-                                     public void onErrorResponse(VolleyError volleyError) {
-                                         txtJoke.setText(volleyError.getMessage());
-                                     }
-                                 }
-        );
+        controller.getJokeById(Joke.RANDOM_ID, new JokeCallback() {
+            @Override
+            public void success(Joke joke) {
+                txtJoke.setText(joke.getText());
+            }
+            @Override
+            public void failure(String errorMessage) {
+                txtJoke.setText(errorMessage);
+            }
+        });
     }
 
 

--- a/app/src/main/java/tests/DatabaseTest.java
+++ b/app/src/main/java/tests/DatabaseTest.java
@@ -26,13 +26,13 @@ public class DatabaseTest extends AndroidTestCase {
         // Here I have my new database which is not connected to the standard database of the App
         Joke joke = new Joke();
         joke.setId(123);
-        joke.setJokeText("jokeText");
+        joke.setText("jokeText");
         joke.setCategories(new ArrayList<String>());
 
         long joke_id = db.createJoke(joke, 0);
 
         String jokeTxt = db.retrieveJokeTextById(joke_id);
-        assertEquals(joke.getJokeText(), jokeTxt);
+        assertEquals(joke.getText(), jokeTxt);
     }
 
     public void testAddCategory() {


### PR DESCRIPTION
We abstract the important pieces into their own classes.
1. We have a `JokeCallback` that has a `success` and `failure` callback method.
2. We have a DAO that converts the data to an object.
3. We have the utility class (a service) that communicates with the server.

At this point it seems that we need about one less layer in all of this.
Discussions suggested that data conversion should happen in the controller,
but technically, the DAO is the method of accessing the data. Either way,
one of those layers probably  needs to go, and is just needless abstraction.

We also remove the `getRandomJoke` methods, and add a constant `Joke.RANDOM_ID`.
The controller knows that when you pass the random id, it should use the
random endpoint. I'm not sure this is the ideal way to do it, but it seemed
better to use `Joke.RANDOM_ID` than `ChuckNorrisApiUtil.RANDOM_JOKE_ID` (the
activity would need to know too much about `Util`, which defeats the purpose
of all these layers).

Since the root URL is the same, and the resource path is the same,
we can just use `"random"` as the id instead of the actual integer `id`.
